### PR TITLE
Optimization to ALS-WR

### DIFF
--- a/src/als-wr.jl
+++ b/src/als-wr.jl
@@ -48,7 +48,7 @@ function update_user(r::UnitRange)
     end
 end
 
-function update_user(u::Int64, model, inp, lambdaI)
+function update_user(u::Int64, model, inp, lambdaI::Float64)
     nzrows, nzvals = items_and_ratings(inp, u)
     Pu = getP(model, nzrows)
     vec = Pu * nzvals
@@ -70,7 +70,7 @@ function update_item(i::Int64)
     update_item(i::Int64, c.model, c.inp, c.lambdaI)
 end
 
-function update_item(i::Int64, model, inp, lambdaI)
+function update_item(i::Int64, model, inp, lambdaI::Float64)
     nzrows, nzvals = users_and_ratings(inp, i)
     Uit = getU(model, nzrows)
     Ui = Uit'


### PR DESCRIPTION
I noticed one of the variables was untyped for two very important function despite both of them are essentially required to be Float64. After typing the value I have noticed surprisingly measurable increase in performance. (Apparently x4?!) I will have to dome some double checking to rule out other sources, but it's certainly a little bizarre that such a "hot" function isn't type checked.

Long story short, added type check to improve performance.